### PR TITLE
Introduce native reflector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^8.3",
         "ext-mbstring": "*",
+        "ext-tokenizer": "*",
         "psr/simple-cache": "^3.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2b20564e2add32f1fac56f49b461b606",
+    "content-hash": "914d6dcf4fd95ba041d0b3f9965b6c99",
     "packages": [
         {
             "name": "psr/simple-cache",
@@ -5780,7 +5780,8 @@
     "prefer-lowest": false,
     "platform": {
         "php": "^8.3",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "ext-tokenizer": "*"
     },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"

--- a/src/Util/File/Reflector/Native/NativeReflector.php
+++ b/src/Util/File/Reflector/Native/NativeReflector.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gember\EventSourcing\Util\File\Reflector\Native;
+
+use Gember\EventSourcing\Util\File\Reflector\ReflectionFailedException;
+use Gember\EventSourcing\Util\File\Reflector\Reflector;
+use PhpToken;
+use ReflectionClass;
+use Override;
+
+final readonly class NativeReflector implements Reflector
+{
+    #[Override]
+    public function reflectClassFromFile(string $file): ReflectionClass
+    {
+        $content = file_get_contents($file);
+
+        if (!$content) {
+            throw ReflectionFailedException::classNotFound($file);
+        }
+
+        $tokens = PhpToken::tokenize($content);
+
+        $namespace = '';
+        $collectNamespace = false;
+
+        foreach ($tokens as $index => $token) {
+            if ($token->is(T_NAMESPACE)) {
+                // Start collecting namespace parts
+                $namespace = '';
+                $collectNamespace = true;
+
+                continue;
+            }
+
+            if ($collectNamespace) {
+                if ($token->is(T_NAME_QUALIFIED)) {
+                    $namespace .= $token->text;
+                } elseif ($token->is(T_WHITESPACE)) {
+                    continue;
+                } else {
+                    // End of namespace declaration
+                    $collectNamespace = false;
+                }
+            }
+
+            if ($token->is([T_CLASS, T_INTERFACE, T_ENUM])) {
+                // Skip anonymous classes
+                $next = $tokens[$index + 1] ?? null;
+                while ($next && $next->is(T_WHITESPACE)) {
+                    ++$index;
+                    $next = $tokens[$index + 1] ?? null;
+                }
+
+                if ($next && $next->is(T_STRING)) {
+                    /** @var class-string $className */
+                    $className = trim($namespace . '\\' . $next->text, '\\');
+
+                    return new ReflectionClass($className);
+                }
+            }
+        }
+
+        throw ReflectionFailedException::classNotFound($file);
+    }
+}

--- a/tests/TestDoubles/Util/File/Reflector/no-class.php
+++ b/tests/TestDoubles/Util/File/Reflector/no-class.php
@@ -1,0 +1,3 @@
+<?php
+
+declare(strict_types=1);

--- a/tests/Util/File/Reflector/Native/NativeReflectorTest.php
+++ b/tests/Util/File/Reflector/Native/NativeReflectorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gember\EventSourcing\Test\Util\File\Reflector\Native;
+
+use Gember\EventSourcing\Test\TestDoubles\UseCase\TestUseCase;
+use Gember\EventSourcing\Util\File\Reflector\Native\NativeReflector;
+use Gember\EventSourcing\Util\File\Reflector\ReflectionFailedException;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Override;
+
+/**
+ * @internal
+ */
+final class NativeReflectorTest extends TestCase
+{
+    private NativeReflector $reflector;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->reflector = new NativeReflector();
+    }
+
+    #[Test]
+    public function itShouldReflectFileName(): void
+    {
+        $reflectionClass = $this->reflector->reflectClassFromFile(__DIR__ . '/../../../../TestDoubles/UseCase/TestUseCase.php');
+
+        self::assertSame(TestUseCase::class, $reflectionClass->getName());
+    }
+
+    #[Test]
+    public function itShouldThrowExceptionWhenClassNotFound(): void
+    {
+        self::expectException(ReflectionFailedException::class);
+
+        $this->reflector->reflectClassFromFile(__DIR__ . '/../../../../TestDoubles/Util/File/Reflector/no-class.php');
+    }
+}


### PR DESCRIPTION
# Description
Introduce native reflector. Making use of native `PHPToken`.

The native approach does (a) avoid a dependency (library), and (b) is faster than Roave BetterReflection.