### PR TITLE
Introduce native Finder

### DIFF
--- a/src/Util/File/Finder/Native/NativeFinder.php
+++ b/src/Util/File/Finder/Native/NativeFinder.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gember\EventSourcing\Util\File\Finder\Native;
+
+use Gember\EventSourcing\Util\File\Finder\Finder;
+use Override;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use RegexIterator;
+
+final readonly class NativeFinder implements Finder
+{
+    private const string REGEX_PHP_FILE = '/^.+\.php$/i';
+
+    #[Override]
+    public function getFiles(string $path): array
+    {
+        $filesIterator = new RegexIterator(
+            new RecursiveIteratorIterator(new RecursiveDirectoryIterator($path)),
+            self::REGEX_PHP_FILE,
+            RegexIterator::GET_MATCH,
+        );
+
+        $files = [];
+
+        /** @var array<int, string> $filePath */
+        foreach ($filesIterator as $filePath) {
+            if (isset($filePath[0]) === false) {
+                continue;
+            }
+
+            $files[] = $filePath[0];
+        }
+
+        return $files;
+    }
+}

--- a/tests/Util/File/Finder/Native/NativeFinderTest.php
+++ b/tests/Util/File/Finder/Native/NativeFinderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Gember\EventSourcing\Test\Util\File\Finder\Native;
+
+use Gember\EventSourcing\Util\File\Finder\Native\NativeFinder;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Override;
+
+/**
+ * @internal
+ */
+final class NativeFinderTest extends TestCase
+{
+    private NativeFinder $finder;
+
+    #[Override]
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->finder = new NativeFinder();
+    }
+
+    #[Test]
+    public function itShouldRetrieveFilesFromFolder(): void
+    {
+        $files = iterator_to_array($this->finder->getFiles(__DIR__ . '/../../'));
+
+        sort($files);
+
+        $files = array_map(
+            fn($file) => str_replace(__DIR__ . '/../../', '', $file),
+            $files,
+        );
+
+        self::assertSame([
+            'Finder/Native/NativeFinderTest.php',
+            'Reflector/Native/NativeReflectorTest.php',
+            'Reflector/ReflectionFailedExceptionTest.php',
+        ], $files);
+    }
+}


### PR DESCRIPTION
# Description
Introduce native Finder. No need for a dependency, native RecursiveDirectoryIterator suffices. This removes the need for another vendor.